### PR TITLE
commented out coinmarketcap as rate source

### DIFF
--- a/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/bitcore/BitcoreExtension.java
+++ b/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/bitcore/BitcoreExtension.java
@@ -20,7 +20,7 @@ package com.generalbytes.batm.server.extensions.extra.bitcore;
 import com.generalbytes.batm.server.extensions.*;
 import com.generalbytes.batm.server.extensions.extra.bitcore.sources.FixPriceRateSource;
 import com.generalbytes.batm.server.extensions.extra.bitcore.wallets.bitcored.BitcoredRPCWallet;
-import com.generalbytes.batm.server.extensions.extra.dash.sources.coinmarketcap.CoinmarketcapRateSource;
+//import com.generalbytes.batm.server.extensions.extra.dash.sources.coinmarketcap.CoinmarketcapRateSource;
 import com.generalbytes.batm.server.extensions.watchlist.IWatchList;
 
 import java.math.BigDecimal;
@@ -100,14 +100,16 @@ public class BitcoreExtension implements IExtension{
                     preferedFiatCurrency = st.nextToken().toUpperCase();
                 }
                 return new FixPriceRateSource(rate,preferedFiatCurrency);
-            } else if ("coinmarketcap".equalsIgnoreCase(exchangeType)) {
+            } 
+            /*
+            else if ("coinmarketcap".equalsIgnoreCase(exchangeType)) {
                 String preferedFiatCurrency = ICurrencies.USD;
                 if (st.hasMoreTokens()) {
                     preferedFiatCurrency = st.nextToken().toUpperCase();
                 }
                 return new CoinmarketcapRateSource(preferedFiatCurrency);
             }
-
+            */
         }
         return null;
     }


### PR DESCRIPTION
Try out if it is enough that coinmarketcap as rate source is implemented in DASH package. For example: in BTC package coinmarketcap as rate source is not implemented, but it works for BTC.